### PR TITLE
Updated RuneLite version and fixed party imports

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ repositories {
 	mavenCentral()
 }
 
-def runeLiteVersion = '1.6.36.2'
+def runeLiteVersion = '1.8.22'
 
 dependencies {
 	compileOnly group: 'net.runelite', name:'client', version: runeLiteVersion

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,1 @@
-rootProject.name = 'example'
+rootProject.name = 'damage-counter'

--- a/src/main/java/com/damagecounter/DamageCounterPlugin.java
+++ b/src/main/java/com/damagecounter/DamageCounterPlugin.java
@@ -61,9 +61,9 @@ import net.runelite.client.util.ImageUtil;
 import net.runelite.client.util.QuantityFormatter;
 import net.runelite.client.util.Text;
 import net.runelite.client.util.WildcardMatcher;
-import net.runelite.client.ws.PartyMember;
-import net.runelite.client.ws.PartyService;
-import net.runelite.client.ws.WSClient;
+import net.runelite.client.party.PartyMember;
+import net.runelite.client.party.PartyService;
+import net.runelite.client.party.WSClient;
 import net.runelite.api.ChatMessageType;
 
 @PluginDescriptor(

--- a/src/main/java/com/damagecounter/DamageOverlay.java
+++ b/src/main/java/com/damagecounter/DamageOverlay.java
@@ -42,7 +42,7 @@ import net.runelite.client.ui.overlay.components.LineComponent;
 import net.runelite.client.ui.overlay.components.TitleComponent;
 import net.runelite.client.ui.overlay.tooltip.TooltipManager;
 import net.runelite.client.util.QuantityFormatter;
-import net.runelite.client.ws.PartyService;
+import net.runelite.client.party.PartyService;
 
 class DamageOverlay extends OverlayPanel
 {

--- a/src/main/java/com/damagecounter/DamageUpdate.java
+++ b/src/main/java/com/damagecounter/DamageUpdate.java
@@ -27,7 +27,7 @@ package com.damagecounter;
 
 import lombok.EqualsAndHashCode;
 import lombok.Value;
-import net.runelite.http.api.ws.messages.party.PartyMemberMessage;
+import net.runelite.client.party.messages.PartyMemberMessage;
 
 @Value
 @EqualsAndHashCode(callSuper = true)


### PR DESCRIPTION
This plugin broke with a recent update to RuneLite party refactoring. Fixed imports to make it work again.