### PR TITLE
Added damage reset delay after killing NPC

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ repositories {
 	mavenCentral()
 }
 
-def runeLiteVersion = '1.8.24.2'
+def runeLiteVersion = '1.8.24.3'
 
 dependencies {
 	compileOnly group: 'net.runelite', name:'client', version: runeLiteVersion

--- a/src/main/java/com/damagecounter/DamageCounterConfig.java
+++ b/src/main/java/com/damagecounter/DamageCounterConfig.java
@@ -3,6 +3,7 @@ package com.damagecounter;
 import net.runelite.client.config.Config;
 import net.runelite.client.config.ConfigGroup;
 import net.runelite.client.config.ConfigItem;
+import net.runelite.client.config.Range;
 
 @ConfigGroup("damagecounter")
 public interface DamageCounterConfig extends Config
@@ -53,4 +54,14 @@ public interface DamageCounterConfig extends Config
 		description = "Also track these NPCs, comma separated"
 	)
 	String additionalNpcs();
+
+	@Range(
+		max = 60
+	)
+	@ConfigItem(
+			keyName = "resetDelay",
+			name = "Damage reset delay",
+			description = "How many seconds to wait until damage is reset after kill. 0 for instant reset"
+	)
+	default int resetDelay() { return 0; }
 }

--- a/src/main/java/com/damagecounter/DamageCounterState.java
+++ b/src/main/java/com/damagecounter/DamageCounterState.java
@@ -1,0 +1,75 @@
+package com.damagecounter;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.Setter;
+import net.runelite.api.NPC;
+import net.runelite.client.util.Text;
+
+import javax.inject.Singleton;
+import java.time.Instant;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+@Singleton
+public class DamageCounterState {
+    @Getter(AccessLevel.PACKAGE)
+    @Setter(AccessLevel.PACKAGE)
+    private String npcName = null;
+
+    @Getter(AccessLevel.PACKAGE)
+    @Setter(AccessLevel.PACKAGE)
+    private NPC barrowsNpc = null;
+
+    @Getter(AccessLevel.PACKAGE)
+    @Setter(AccessLevel.PACKAGE)
+    private int boss = 0;
+
+    @Getter(AccessLevel.PACKAGE)
+    private final Map<String, DamageMember> members = new ConcurrentHashMap<>();
+    @Getter(AccessLevel.PACKAGE)
+    private final DamageMember total = new DamageMember("Total");
+
+
+    @Getter(AccessLevel.PACKAGE)
+    @Setter(AccessLevel.PACKAGE)
+    private List<String> additionalNpcs = Collections.emptyList();
+
+    private final ScheduledExecutorService scheduler = Executors.newSingleThreadScheduledExecutor();
+
+    private final Runnable resetDamage = () -> {
+        for (DamageMember damageMember : members.values()) {
+            damageMember.reset();
+        }
+        total.reset();
+    };
+
+    void addAdditionalNpcsFromString(String npcsList) {
+        additionalNpcs = npcsList != null ? Text.fromCSV(npcsList) : Collections.emptyList();
+    }
+
+    void setEndTime() {
+        Instant endTime = Instant.now();
+        total.setEnd(endTime);
+        for (DamageMember damageMember : members.values()) {
+            damageMember.setEnd(endTime);
+        }
+    }
+
+    void reset(int delay) {
+        barrowsNpc = null;
+        boss = 0;
+        npcName = null;
+
+        if (delay <= 0) {
+            scheduler.execute(resetDamage);
+        } else {
+            scheduler.schedule(resetDamage, delay, TimeUnit.SECONDS);
+        }
+    }
+}

--- a/src/main/java/com/damagecounter/DamageMember.java
+++ b/src/main/java/com/damagecounter/DamageMember.java
@@ -29,6 +29,7 @@ import java.time.Duration;
 import java.time.Instant;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import lombok.Setter;
 
 @RequiredArgsConstructor
 @Getter
@@ -36,6 +37,7 @@ class DamageMember
 {
 	private final String name;
 	private Instant start;
+	@Setter
 	private Instant end;
 	private int damage;
 	public static boolean overlayHide = true;


### PR DESCRIPTION
Enables party members to view everybody's dealt damage before it is reset after configured delay.

Also included changes:
Refactored stateful variables from plugin instance into a separate instance
Bumped RuneLite version to 1.8.24.3